### PR TITLE
add rails version to migration

### DIFF
--- a/db/migrate/20170112204309_add_printful_variant_id_to_spree_variants.rb
+++ b/db/migrate/20170112204309_add_printful_variant_id_to_spree_variants.rb
@@ -1,4 +1,4 @@
-class AddPrintfulVariantIdToSpreeVariants < ActiveRecord::Migration
+class AddPrintfulVariantIdToSpreeVariants < ActiveRecord::Migration[4.2]
   def change
     add_column :spree_variants, :printful_variant_id, :integer
   end


### PR DESCRIPTION
This is required in newer versions of rails. I believe the version
number is supposed to be the lowest version that the migration is
compatible with.